### PR TITLE
Add a man page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "toml-adapt"
 version = "0.1.0"
 description = ""
 authors = ["iztokf <iztokf@fedoraproject.org>"]
+include = ["toml-adapt.1"]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/toml-adapt.1
+++ b/toml-adapt.1
@@ -1,0 +1,48 @@
+.TH TOML\-ADAPT "1" "June 2021" "" "User Commands"
+.SH NAME
+toml\-adapt \- adapt TOML files
+.SH SYNOPSIS
+.B toml\-adapt
+.RB [ \-h ]
+.RB [ \-path\ \fIPATH ]
+.RB [ \-a\  { change , add , remove }]
+.RB [ \-dep\ \fIDEP ]
+.RB [ \-ver\ \fIVER ]
+.\" .SH DESCRIPTION
+.SH OPTIONS
+.TP
+.BR \-h ,\  \-\-help
+Show a help message and exit
+.TP
+.B \-path\ \fIPATH
+Path to the
+.B .toml
+file
+.TP
+.BR \-a \ { change , add , remove }
+Select action
+.TP
+.B \-dep\ \fIDEP
+Dependency name
+.TP
+.B \-ver\ \fIVER
+Version of dependency
+.SH EXAMPLES
+.TP
+.B Change dependency
+.IP
+.EX
+.B toml\-adapt \-path\ \fIpyproject.toml\fB \-a\ change \-dep\ \fIniaclass\fB \-ver\ \fI0.1.0
+.EE
+.TP
+.B Add dependency
+.IP
+.EX
+.B toml\-adapt \-path\ \fIpyproject.toml\fB \-a\ add \-dep\ \fIniaclass\fB \-ver\ \fI0.1.0
+.EE
+.TP
+.B Remove dependency
+.IP
+.EX
+.B toml\-adapt \-path\ \fIpyproject.toml\fB \-a\ remove \-dep\ \fIniaclass\fB \-ver\ \fI0.1.0
+.EE


### PR DESCRIPTION
This adds a man page in `groff_man(7)` format, based on the `--help` output and the README, and adds it to the source distribution.

Since man pages are platform-dependent, I made no attempt to install it, only to make it available for, e.g., Linux distribution packagers.