### PR TITLE
Include the man page in the sdist only, not in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "toml-adapt"
 version = "0.1.1"
 description = ""
 authors = ["iztokf <iztokf@fedoraproject.org>"]
-include = ["toml-adapt.1"]
+include = [ { path = "toml-adapt.1", format = "sdist" } ]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
I still don’t have much practice with `pyproject.toml` as opposed to `setup.py`/`MANIFEST.in`, so I didn’t realize that adding a file to `include` caused it to be included in both the sdist and the wheel.

This is why the man page gets installed in the python site-packages directory, and reported as an unpackaged file in your [Fedora RPM build](https://src.fedoraproject.org/rpms/python-toml-adapt/).